### PR TITLE
Spell correct: capabilities

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkCapabilities.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkCapabilities.java
@@ -22,7 +22,7 @@ public class ShadowNetworkCapabilities {
     return Shadow.newInstanceOf(NetworkCapabilities.class);
   }
 
-  /** Updates the transport types for this network capablities to include {@code transportType}. */
+  /** Updates the transport types for this network capabilities to include {@code transportType}. */
   @HiddenApi
   @Implementation
   public NetworkCapabilities addTransportType(int transportType) {
@@ -30,7 +30,7 @@ public class ShadowNetworkCapabilities {
         .addTransportType(transportType);
   }
 
-  /** Updates the transport types for this network capablities to remove {@code transportType}. */
+  /** Updates the transport types for this network capabilities to remove {@code transportType}. */
   @HiddenApi
   @Implementation
   public NetworkCapabilities removeTransportType(int transportType) {


### PR DESCRIPTION
Correct spelling of javadoc from "capablities" to "capabilities".

### Overview

Correct spelling. Javadoc only.

### Proposed Changes

Correct spelling of javadoc from "capablities" to "capabilities" in `ShadowNetworkCapabilities`.

